### PR TITLE
Make histogram sample type optionally configurable via folsom_ets:notify

### DIFF
--- a/src/folsom_ets.erl
+++ b/src/folsom_ets.erl
@@ -397,6 +397,13 @@ notify(Name, Value, histogram, false) ->
     add_handler(histogram, Name),
     folsom_metrics_histogram:update(Name, Value),
     ok;
+notify(Name, Value, {histogram, SampleType}, true) ->
+    folsom_metrics_histogram:update(Name, Value),
+    ok;
+notify(Name, Value, {histogram, SampleType}, false) ->
+    add_handler(histogram, Name, SampleType),
+    folsom_metrics_histogram:update(Name, Value),
+    ok;
 notify(Name, Value, history, true) ->
     [{_, #metric{history_size = HistorySize}}] = ets:lookup(?FOLSOM_TABLE, Name),
     folsom_metrics_history:update(Name, HistorySize, Value),
@@ -436,4 +443,3 @@ notify(Name, Value, spiral, false) ->
     ok;
 notify(_, _, Type, _) ->
     {error, Type, unsupported_metric_type}.
-

--- a/src/folsom_ets.erl
+++ b/src/folsom_ets.erl
@@ -397,7 +397,7 @@ notify(Name, Value, histogram, false) ->
     add_handler(histogram, Name),
     folsom_metrics_histogram:update(Name, Value),
     ok;
-notify(Name, Value, {histogram, SampleType}, true) ->
+notify(Name, Value, {histogram, _SampleType}, true) ->
     folsom_metrics_histogram:update(Name, Value),
     ok;
 notify(Name, Value, {histogram, SampleType}, false) ->


### PR DESCRIPTION
Sometimes you don't want a slide histogram when you send to folsom_ets:notify.

This lets a user optionally provide a SampleType for the histogram type.
