### PR TITLE
Fix README to include ensure_all_started

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,13 @@ folsom can be run standalone or embedded in an Erlang application.
 
        $ erl -pa ebin deps/*/ebin
 
+       > application:ensure_all_started(bear). % start dependency first
        > folsom:start(). % this creates the needed ETS tables and starts a gen_server
 
 You can also start it as an application:
 
        $ erl -pa ebin deps/*/ebin
-       > application:start(folsom).
+       > application:ensure_all_started(folsom).
 
        $ erl -pa ebin deps/*/ebin -s folsom
 


### PR DESCRIPTION
`folsom` depends on [bear](https://github.com/folsom-project/bear) (as of a8f36eb). The "Building and Running" section in `README.md` does not reflect that. Here, `application:ensure_all_started(folsom)` or something similar is needed to actually start the `folsom` application. This is simple enough when running `folsom` from the Erlang shell, but more complicated if `folsom` is to be started using `erl ... -s folsom`. Therefore, this pull request only fixes the simple case, as handling `-s` should be discussed further.