### PR TITLE
Filter out "forker" non-inet port

### DIFF
--- a/src/folsom_vm_metrics.erl
+++ b/src/folsom_vm_metrics.erl
@@ -55,7 +55,11 @@ get_process_info() ->
     [{pid_port_fun_to_atom(Pid), get_process_info(Pid)} || Pid <- processes()].
 
 get_port_info() ->
-    [{pid_port_fun_to_atom(Port), get_port_info(Port)} || Port <- erlang:ports()].
+    [{pid_port_fun_to_atom(Port), get_port_info(Port)} || Port <- erlang:ports(),
+        begin
+            {name, Type} = erlang:port_info(Port, name), Type /= "forker"
+        end
+    ].
 
 get_ets_info() ->
     [{Tab, get_ets_dets_info(ets, Tab)} || Tab <- ets:all()].


### PR DESCRIPTION
Some ports won't allow this trick anymore:

[ catch inet:getstat(Port) || Port <- erlang:ports()].

For example with port name "forker" this shuts down the entire VM. So we
have to filter out at least this "forker" port. Even better we should
check only inet-related ones ("udp_inet, "tcp_inet", "sctp_inet"). See
this thread for further details:

https://bugs.erlang.org/browse/ERL-389

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>