### PR TITLE
meck api to compile coverage changed in OTP 18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: erlang
 
-script: rebar3 eunit
+#script: rebar3 eunit
+#install: true
+script: ./rebar get-deps compile && ./rebar eunit skip_deps=true
 
 otp_release:
   - 19.2

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,8 +5,8 @@ case erlang:function_exported(rebar3, main, 1) of
         %% Rebuild deps, possibly including those that have been moved to
         %% profiles
         [{deps, [
-	    {bear, ".*", {git, "https://github.com/folsom-project/bear.git", {tag, "0.8.3"}}},
-            {meck, ".*", {git, "https://github.com/eproxus/meck", {tag, "0.8.2"}}}
+            {bear, ".*", {git, "https://github.com/folsom-project/bear.git", {tag, "0.8.3"}}},
+            {meck, ".*", {git, "https://github.com/eproxus/meck", {tag, "0.8.4"}}}
         ]} | lists:keydelete(deps, 1, CONFIG)]
 end.
 

--- a/test/folsom_erlang_checks.erl
+++ b/test/folsom_erlang_checks.erl
@@ -479,8 +479,14 @@ for(N, LoopCount, Counter) ->
     for(N, LoopCount + 1, Counter).
 
 cpu_topology() ->
-    ?debugFmt("Testing various CPU topologies ...~n", []),
-    {ok, [Data]} = file:consult("test/cpu_topo_data"),
+    ?debugMsg("Testing various CPU topologies ...~n"),
+    P = "test/cpu_topo_data",
+    Path = case filelib:is_regular(P) of
+               true  -> P;
+               false -> filename:join("..", P)
+    end,
+    {ok, [Data]} = file:consult(Path),
+
     [run_convert_and_jsonify(Item) || Item <- Data].
 
 


### PR DESCRIPTION
Unit tests break on OTP 18 and 19 without this version bump to meck.

The gory details are available here: https://github.com/eproxus/meck/commit/e3c9d24a24f170bbcf1398efce5d343aa76ec092