### PR TITLE
uniform s util

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,5 +5,8 @@
     {meck, ".*", {git, "git://github.com/eproxus/meck", {tag, "0.8.2"}}}
 ]}.
 
-{erl_opts, [debug_info]}.
+{erl_opts, [
+           debug_info,
+           {platform_define, "^((1[8|9])|2)", rand_module}
+           ]}.
 {cover_enabled, true}.

--- a/src/folsom_sample_exdec.erl
+++ b/src/folsom_sample_exdec.erl
@@ -64,7 +64,7 @@ get_values(#exdec{reservoir = Reservoir}) ->
 update(#exdec{reservoir = Reservoir, alpha = Alpha, start = Start, n = N, size = Size, seed = Seed} = Sample, Value, Timestamp) when N =< Size ->
     % since N is =< Size we can just add the new value to the sample
 
-    {Rand, New_seed} = random:uniform_s(N, Seed),
+    {Rand, New_seed} = folsom_utils:uniform_s(N, Seed),
     Priority = priority(Alpha, Timestamp, Start, Rand),
     true = ets:insert(Reservoir, {Priority, Value}),
 
@@ -73,7 +73,7 @@ update(#exdec{reservoir = Reservoir, alpha = Alpha, start = Start, n = N, seed =
     % when N is not =< Size we need to check to see if the priority of
     % the new value is greater than the first (smallest) existing priority
 
-    {Rand, NewSeed} = random:uniform_s(N, Seed),
+    {Rand, NewSeed} = folsom_utils:uniform_s(N, Seed),
     Priority = priority(Alpha, Timestamp, Start, Rand),
     First = ets:first(Reservoir),
 

--- a/src/folsom_sample_slide_uniform.erl
+++ b/src/folsom_sample_slide_uniform.erl
@@ -45,7 +45,7 @@ update(#slide_uniform{reservoir = Reservoir, size = Size} = Sample0, Value) ->
     MCnt = folsom_utils:update_counter(Reservoir, Moment, 1),
     Sample = case MCnt > Size of
                  true ->
-                     {Rnd, _NewSeed} = random:uniform_s(MCnt, Now),
+                     {Rnd, _NewSeed} = folsom_utils:uniform_s(MCnt, Now),
                      maybe_update(Reservoir, {{Moment, Rnd}, Value}, Size),
                      Sample0;
                  false ->

--- a/src/folsom_sample_uniform.erl
+++ b/src/folsom_sample_uniform.erl
@@ -49,7 +49,7 @@ update(#uniform{size = Size, reservoir = Reservoir, n = N} = Sample, Value) when
 
 update(#uniform{reservoir = Reservoir, size = Size, n = N, seed = Seed} = Sample,
        Value) ->
-    {Rnd, New_seed} = random:uniform_s(N, Seed),
+    {Rnd, New_seed} = folsom_utils:uniform_s(N, Seed),
     maybe_update(Rnd, Size, Value, Reservoir),
     Sample#uniform{n = N + 1, seed = New_seed}.
 

--- a/src/folsom_utils.erl
+++ b/src/folsom_utils.erl
@@ -109,6 +109,6 @@ uniform_s(N, Seed) ->
     %% rand module use a different rand methos, doesn't need to use the seed
     {rand:uniform(N), Seed}.
 -else.
-uniform_s(N, State) ->
+uniform_s(N, Seed) ->
     random:uniform_s(N, Seed).
 -endif.

--- a/src/folsom_utils.erl
+++ b/src/folsom_utils.erl
@@ -33,7 +33,8 @@
          timestamp/0,
          get_ets_size/1,
          update_counter/3,
-         update_counter_no_exceptions/3
+         update_counter_no_exceptions/3,
+         uniform_s/2
         ]).
 
 to_atom(Binary) when is_binary(Binary) ->
@@ -102,3 +103,12 @@ update_counter_no_exceptions(Tid, Key, Value) when is_integer(Value) ->
         _ ->
             ets:update_counter(Tid, Key, Value)
     end.
+
+-ifdef(rand_module).
+uniform_s(N, Seed) ->
+    %% rand module use a different rand methos, doesn't need to use the seed
+    {rand:uniform(N), Seed}.
+-else.
+uniform_s(N, State) ->
+    random:uniform_s(N, Seed).
+-endif.


### PR DESCRIPTION
I check it again, and found the #14 should be revert. 
Because the `rand` module and  `random`  module use different method.
`rand:uniform_s(N :: integer() >= 1, State :: state()) ->  {X :: integer() >= 1, NewState :: state()}`, 
while state() is `state() = {alg_handler(), alg_state()}` 

`random:uniform_s(N, State0) -> {integer(), State1} `, 
while state0 and State1 is `ran() = {integer(), integer(), integer()}`

They are different and not compitable.
In my solution, I do not use the seed at all and solve the problem.
@mrallen1 @joewilliams 
