### PR TITLE
in 19, the RANDOM is rand, and uniform_s 2nd argument is to be ?SEED,…

### DIFF
--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -18,7 +18,16 @@
 -ifdef(use_rand).
 -define(SEED, rand:seed(exsplus)).
 -else.
--define(SEED, random:seed(os:timestamp())).
+-define(SEED, fun() ->
+                      case random:seed(os:timestamp()) of
+                          undefined ->
+                              random:seed(os:timestamp());
+                          State ->
+                              State
+                      end
+              end
+       ).
+
 -endif.
 
 -record(spiral, {

--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -18,16 +18,7 @@
 -ifdef(use_rand).
 -define(SEED, rand:seed(exsplus)).
 -else.
--define(SEED, fun() ->
-                      case random:seed(os:timestamp()) of
-                          undefined ->
-                              random:seed(os:timestamp());
-                          State ->
-                              State
-                      end
-              end
-       ).
-
+-define(SEED, os:timestamp()).
 -endif.
 
 -record(spiral, {

--- a/src/folsom_sample_slide_uniform.erl
+++ b/src/folsom_sample_slide_uniform.erl
@@ -51,7 +51,7 @@ update(#slide_uniform{reservoir = Reservoir, size = Size} = Sample0, Value) ->
     MCnt = folsom_utils:update_counter(Reservoir, Moment, 1),
     Sample = case MCnt > Size of
                  true ->
-                     {Rnd, _NewSeed} = ?RANDOM:uniform_s(MCnt, Now),
+                     {Rnd, _NewSeed} = ?RANDOM:uniform_s(MCnt, ?SEED),
                      maybe_update(Reservoir, {{Moment, Rnd}, Value}, Size),
                      Sample0;
                  false ->


### PR DESCRIPTION
… which would change as version detected.
@mrallen1 I think the argument should be ?SEED.
I make a pr to exometer_core, see  Feuerlabs/exometer_core#94. And I found the log fail, and finally I debug this should be the reason. 