### PR TITLE
Expose instant rate in folsom_meter

### DIFF
--- a/src/folsom_ewma.erl
+++ b/src/folsom_ewma.erl
@@ -29,6 +29,7 @@
 
 -module(folsom_ewma).
 
+-define(INSTANT_ALPHA, 1).
 -define(M1_ALPHA,   1 - math:exp(-5 / 60.0)).
 -define(M5_ALPHA,   1 - math:exp(-5 / 60.0 / 5)).
 -define(M15_ALPHA,  1 - math:exp(-5 / 60.0 / 15)).
@@ -46,6 +47,7 @@
          new/2,
          rate/1,
          tick/1,
+         instant_ewma/0,
          one_minute_ewma/0,
          five_minute_ewma/0,
          fifteen_minute_ewma/0,
@@ -53,6 +55,8 @@
 
 
 % API
+instant_ewma() ->
+  new(?INSTANT_ALPHA, 5).
 
 one_minute_ewma() ->
     new(?M1_ALPHA, 5).
@@ -72,6 +76,9 @@ new(Alpha, Interval) ->
 update(#ewma{total = Total} = EWMA, Value) ->
     EWMA#ewma{total = Total + Value}.
 
+tick(#ewma{total = Total, rate = _Rate, initialized = _Init, interval = Interval, alpha = ?INSTANT_ALPHA} = EWMA) ->
+  InstantRate = Total / Interval,
+  EWMA#ewma{rate = InstantRate, total = 0};
 tick(#ewma{total = Total, rate = Rate, initialized = Init, interval = Interval, alpha = Alpha} = EWMA) ->
     InstantRate = Total / Interval,
     Rate1 = rate_calc(Init, Alpha, Rate, InstantRate),

--- a/src/folsom_metrics_meter.erl
+++ b/src/folsom_metrics_meter.erl
@@ -34,6 +34,7 @@
 
 
 -record(meter, {
+          instant,
           one,
           five,
           fifteen,
@@ -45,31 +46,38 @@
 -include("folsom.hrl").
 
 new(Name) ->
+    Instant = folsom_ewma:instant_ewma(),
     OneMin = folsom_ewma:one_minute_ewma(),
     FiveMin = folsom_ewma:five_minute_ewma(),
     FifteenMin = folsom_ewma:fifteen_minute_ewma(),
     OneDay = folsom_ewma:one_day_ewma(),
 
     ets:insert(?METER_TABLE,
-               {Name, #meter{one = OneMin,
+               {Name, #meter{
+                             instant = Instant,
+                             one = OneMin,
                              five = FiveMin,
                              fifteen = FifteenMin,
                              day = OneDay,
                              start_time = folsom_utils:now_epoch_micro()}}).
 
 tick(Name) ->
-    #meter{one = OneMin,
+    #meter{instant = Instant,
+           one = OneMin,
            five = FiveMin,
            fifteen = FifteenMin,
            day = OneDay} = Meter = get_value(Name),
 
+    Instant1 = folsom_edma:tick(Instant),
     OneMin1 = folsom_ewma:tick(OneMin),
     FiveMin1 = folsom_ewma:tick(FiveMin),
     FifteenMin1 = folsom_ewma:tick(FifteenMin),
     OneDay1 = folsom_ewma:tick(OneDay),
 
     ets:insert(?METER_TABLE,
-               {Name, Meter#meter{one = OneMin1,
+               {Name, Meter#meter{
+                                  instant = Instant1,
+                                  one = OneMin1,
                                   five = FiveMin1,
                                   fifteen = FifteenMin1,
                                   day = OneDay1}}).
@@ -78,25 +86,30 @@ mark(Name) ->
     mark(Name, 1).
 
 mark(Name, Value) ->
-    #meter{count = Count,
+    #meter{
+           instant = Instant,
+           count = Count,
            one = OneMin,
            five = FiveMin,
            fifteen = FifteenMin,
            day = OneDay} = Meter = get_value(Name),
 
+    Instant1 = folsom_ewma:update(Instant, Value),
     OneMin1 = folsom_ewma:update(OneMin, Value),
     FiveMin1 = folsom_ewma:update(FiveMin, Value),
     FifteenMin1 = folsom_ewma:update(FifteenMin, Value),
     OneDay1 = folsom_ewma:update(OneDay, Value),
 
     ets:insert(?METER_TABLE, {Name, Meter#meter{count = Count + Value,
+                                                instant = Instant1,
                                                 one = OneMin1,
                                                 five = FiveMin1,
                                                 fifteen = FifteenMin1,
                                                 day = OneDay1}}).
 
 get_values(Name) ->
-    #meter{one = OneMin,
+    #meter{instant = Instant,
+           one = OneMin,
            five = FiveMin,
            fifteen = FifteenMin,
            day = OneDay,
@@ -104,6 +117,7 @@ get_values(Name) ->
 
     L = [
          {count, Count},
+         {instant, get_rate(Instant)},
          {one, get_rate(OneMin)},
          {five, get_rate(FiveMin)},
          {fifteen, get_rate(FifteenMin)},
@@ -115,11 +129,12 @@ get_values(Name) ->
     [ {K,V} || {K,V} <- L, V /= undefined ].
 
 get_acceleration(Name) ->
-    #meter{one = OneMin,
+    #meter{instant = Instant,
+           one = OneMin,
            five = FiveMin,
            fifteen = FifteenMin} = get_value(Name),
 
-    [
+    [{instant_to_one, calc_acceleration(get_rate(Instant), get_rate(OneMin), 60)},
      {one_to_five, calc_acceleration(get_rate(OneMin), get_rate(FiveMin), 300)},
      {five_to_fifteen, calc_acceleration(get_rate(FiveMin), get_rate(FifteenMin), 600)},
      {one_to_fifteen, calc_acceleration(get_rate(OneMin), get_rate(FifteenMin), 900)}

--- a/src/folsom_metrics_meter.erl
+++ b/src/folsom_metrics_meter.erl
@@ -68,7 +68,7 @@ tick(Name) ->
            fifteen = FifteenMin,
            day = OneDay} = Meter = get_value(Name),
 
-    Instant1 = folsom_edma:tick(Instant),
+    Instant1 = folsom_ewma:tick(Instant),
     OneMin1 = folsom_ewma:tick(OneMin),
     FiveMin1 = folsom_ewma:tick(FiveMin),
     FifteenMin1 = folsom_ewma:tick(FifteenMin),


### PR DESCRIPTION
Instant rate can be very useful and it was already available  in folsom for `one-`, `five-`, and `fifteen-minute` calculations.   This PR will merely expose it.   I tested it with exometer by changing my config from
` {exometer_report_graphite, {select, [{ {[ tls | '_'], meter, '_'}, [], ['$_'] }]}, [count, mean, one, five, fifteen], 1000},`
to 
` {exometer_report_graphite, {select, [{ {[ tls | '_'], meter, '_'}, [], ['$_'] }]}, [count, mean, instant, one, five, fifteen], 1000},` 
We ran it inside an integration test where we were measuring outgoing packet rate with an existing and well-tested Codahale-inspired C++ library.   Incoming packets were received by erlang app using  exometer using this version of folsom.  Our incoming and outgoing instant rates were very close together and as expected.   