### PR TITLE
Fix repo link

### DIFF
--- a/src/folsom.app.src
+++ b/src/folsom.app.src
@@ -16,5 +16,5 @@
   {mod, {folsom, []}},
   {maintainers, ["Joe Williams"]},
   {licenses, ["Apache 2"]},
-  {links, [{"Github", "https://github.com/project-folsom/folsom"}]}
+  {links, [{"Github", "https://github.com/folsom-project/folsom"}]}
  ]}.


### PR DESCRIPTION
The package project on hex.pm (https://hex.pm/packages/folsom/) shows an outdated URL that points to a 404 page. I think this should fix it.