### PR TITLE
Prevent races on metric ETS tables creation

### DIFF
--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -84,6 +84,12 @@
           tid
           }).
 
+-record(metric, {
+          tags = sets:new(),
+          type,
+          history_size
+         }).
+
 -define(SYSTEM_INFO, [
                       allocated_areas,
                       allocator,

--- a/src/folsom.app.src
+++ b/src/folsom.app.src
@@ -2,7 +2,7 @@
 {application, folsom,
  [
   {description, "Erlang based metrics system"},
-  {vsn, "0.8.8"}, %% should be updated when new tag added to repo
+  {vsn, "0.9.0"}, %% should be updated when new tag added to repo
   {modules, []},
   {registered, [folsom_meter_timer_server,
                 folsom_metrics_histogram_ets,

--- a/src/folsom_ets.erl
+++ b/src/folsom_ets.erl
@@ -48,12 +48,6 @@
          get_tags/1
         ]).
 
--record(metric, {
-          tags = sets:new(),
-          type,
-          history_size
-         }).
-
 -include("folsom.hrl").
 
 %%%===================================================================
@@ -196,38 +190,26 @@ get_tags(Name) ->
 
 maybe_add_handler(counter, Name, false) ->
     true = folsom_metrics_counter:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = counter}}),
     ok;
 maybe_add_handler(gauge, Name, false) ->
     true = folsom_metrics_gauge:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = gauge}}),
     ok;
 maybe_add_handler(histogram, Name, false) ->
     true = folsom_metrics_histogram:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = histogram}}),
     ok;
 maybe_add_handler(duration, Name, false) ->
-    true = folsom_metrics_histogram:new(Name),
     true = folsom_metrics_duration:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = duration}}),
     ok;
 maybe_add_handler(history, Name, false) ->
-    ok = folsom_metrics_history:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = history, history_size = ?DEFAULT_SIZE}}),
-    ok;
+    ok = folsom_metrics_history:new(Name);
 maybe_add_handler(meter, Name, false) ->
-    ok = folsom_meter_timer_server:register(Name, folsom_metrics_meter),
     true = folsom_metrics_meter:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = meter}}),
     ok;
 maybe_add_handler(meter_reader, Name, false) ->
-    ok = folsom_meter_timer_server:register(Name, folsom_metrics_meter_reader),
     true = folsom_metrics_meter_reader:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = meter_reader}}),
     ok;
 maybe_add_handler(spiral, Name, false) ->
     true = folsom_metrics_spiral:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = spiral}}),
     ok;
 maybe_add_handler(Type, _, false) ->
     {error, Type, unsupported_metric_type};
@@ -236,15 +218,11 @@ maybe_add_handler(_, Name, true) ->
 
 maybe_add_handler(histogram, Name, SampleType, false) ->
     true = folsom_metrics_histogram:new(Name, SampleType),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = histogram}}),
     ok;
 maybe_add_handler(history, Name, SampleSize, false) ->
-    ok = folsom_metrics_history:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = history, history_size = SampleSize}}),
-    ok;
+    ok = folsom_metrics_history:new(Name, SampleSize);
 maybe_add_handler(spiral, Name, Update, false) ->
     true = folsom_metrics_spiral:new(Name, Update),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = spiral}}),
     ok;
 maybe_add_handler(Type, _, _, false) ->
     {error, Type, unsupported_metric_type};
@@ -253,7 +231,6 @@ maybe_add_handler(_, Name, _, true) ->
 
 maybe_add_handler(histogram, Name, SampleType, SampleSize, false) ->
     true = folsom_metrics_histogram:new(Name, SampleType, SampleSize),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = histogram}}),
     ok;
 maybe_add_handler(Type, _, _, _, false) ->
     {error, Type, unsupported_metric_type};
@@ -262,12 +239,9 @@ maybe_add_handler(_, Name, _, _, true) ->
 
 maybe_add_handler(histogram, Name, SampleType, SampleSize, Alpha, false) ->
     true = folsom_metrics_histogram:new(Name, SampleType, SampleSize, Alpha),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = histogram}}),
     ok;
 maybe_add_handler(duration, Name, SampleType, SampleSize, Alpha, false) ->
-    true = folsom_metrics_histogram:new(Name, SampleType, SampleSize, Alpha),
-    true = folsom_metrics_duration:new(Name),
-    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = duration}}),
+    true = folsom_metrics_duration:new(Name, SampleType, SampleSize, Alpha),
     ok;
 maybe_add_handler(Type, _, _, _, _, false) ->
     {error, Type, unsupported_metric_type};

--- a/src/folsom_metrics_counter.erl
+++ b/src/folsom_metrics_counter.erl
@@ -24,6 +24,8 @@
 
 -module(folsom_metrics_counter).
 
+-behaviour(gen_server).
+
 -export([new/1,
          inc/1,
          inc/2,
@@ -31,15 +33,23 @@
          dec/2,
          get_value/1,
          clear/1,
-	 delete/1]).
+         delete/1]).
+
+-export([start_link/0]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3, format_status/2]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
 
 -define(WIDTH, 16). %% Keep this a power of two
 
 -include("folsom.hrl").
 
 new(Name) ->
-    Counters = [{{Name,N}, 0} || N <- lists:seq(0,?WIDTH-1)],
-    ets:insert(?COUNTER_TABLE, Counters).
+    gen_server:call(?SERVER, {new, Name}).
 
 inc(Name) ->
     ets:update_counter(?COUNTER_TABLE, key(Name), 1).
@@ -58,7 +68,8 @@ get_value(Name) ->
     Count.
 
 clear(Name) ->
-    new(Name).
+    Counters = [{{Name,N}, 0} || N <- lists:seq(0,?WIDTH-1)],
+    true = ets:insert(?COUNTER_TABLE, Counters).
 
 delete(Name) ->
     Counters = [{Name,N} || N <- lists:seq(0,?WIDTH-1)],
@@ -69,3 +80,46 @@ key(Name) ->
     X = erlang:system_info(scheduler_id),
     Rnd = X band (?WIDTH-1),
     {Name, Rnd}.
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    process_flag(trap_exit, true),
+    {ok, #state{}}.
+
+handle_call({new, Name}, _From, State) ->
+    Reply = case ets:member(?COUNTER_TABLE, Name) of
+                false ->
+                    Counters = [{{Name,N}, 0} || N <- lists:seq(0,?WIDTH-1)],
+                    true = ets:insert(?COUNTER_TABLE, Counters),
+                    ets:insert(?FOLSOM_TABLE, {Name, #metric{type = counter}});
+                true ->
+                    true
+            end,
+    {reply, Reply, State};
+handle_call({clear, Name}, _From, State) ->
+    Reply = case ets:member(?COUNTER_TABLE, Name) of
+                false ->
+                    Counters = [{{Name,N}, 0} || N <- lists:seq(0,?WIDTH-1)],
+                    true = ets:insert(?COUNTER_TABLE, Counters),
+                    ets:insert(?FOLSOM_TABLE, {Name, #metric{type = counter}});
+                true ->
+                    true
+            end,
+    {reply, Reply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+format_status(_Opt, Status) ->
+    Status.

--- a/src/folsom_metrics_meter.erl
+++ b/src/folsom_metrics_meter.erl
@@ -24,6 +24,8 @@
 
 -module(folsom_metrics_meter).
 
+-behaviour(gen_server).
+
 -export([new/1,
          tick/1,
          mark/1,
@@ -32,6 +34,14 @@
          get_acceleration/1
         ]).
 
+-export([start_link/0]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3, format_status/2]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
 
 -record(meter, {
           instant,
@@ -46,20 +56,7 @@
 -include("folsom.hrl").
 
 new(Name) ->
-    Instant = folsom_ewma:instant_ewma(),
-    OneMin = folsom_ewma:one_minute_ewma(),
-    FiveMin = folsom_ewma:five_minute_ewma(),
-    FifteenMin = folsom_ewma:fifteen_minute_ewma(),
-    OneDay = folsom_ewma:one_day_ewma(),
-
-    ets:insert(?METER_TABLE,
-               {Name, #meter{
-                             instant = Instant,
-                             one = OneMin,
-                             five = FiveMin,
-                             fifteen = FifteenMin,
-                             day = OneDay,
-                             start_time = folsom_utils:now_epoch_micro()}}).
+    gen_server:call(?SERVER, {new, Name}).
 
 tick(Name) ->
     #meter{instant = Instant,
@@ -166,3 +163,48 @@ get_rate(Value1, Value2, Interval) ->
     Delta = Value1 - Value2,
     Delta / Interval.
 
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    process_flag(trap_exit, true),
+    {ok, #state{}}.
+
+handle_call({new, Name}, _From, State) ->
+    Reply = case ets:member(?METER_TABLE, Name) of
+                false ->
+                    ok = folsom_meter_timer_server:register(Name, folsom_metrics_meter),
+                    Instant = folsom_ewma:instant_ewma(),
+                    OneMin = folsom_ewma:one_minute_ewma(),
+                    FiveMin = folsom_ewma:five_minute_ewma(),
+                    FifteenMin = folsom_ewma:fifteen_minute_ewma(),
+                    OneDay = folsom_ewma:one_day_ewma(),
+
+                    ets:insert(?METER_TABLE,
+                               {Name, #meter{
+                                         instant = Instant,
+                                         one = OneMin,
+                                         five = FiveMin,
+                                         fifteen = FifteenMin,
+                                         day = OneDay,
+                                         start_time = folsom_utils:now_epoch_micro()}}),
+                    ets:insert(?FOLSOM_TABLE, {Name, #metric{type = meter}});
+                true ->
+                    true
+            end,
+    {reply, Reply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+format_status(_Opt, Status) ->
+    Status.

--- a/src/folsom_metrics_meter_reader.erl
+++ b/src/folsom_metrics_meter_reader.erl
@@ -26,6 +26,8 @@
 
 -module(folsom_metrics_meter_reader).
 
+-behaviour(gen_server).
+
 -export([new/1,
          tick/1,
          mark/1,
@@ -34,6 +36,14 @@
          get_acceleration/1
         ]).
 
+-export([start_link/0]).
+
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3, format_status/2]).
+
+-define(SERVER, ?MODULE).
+
+-record(state, {}).
 
 -record(meter_reader, {
           instant,
@@ -48,17 +58,7 @@
 -include("folsom.hrl").
 
 new(Name) ->
-    Instant = folsom_ewma:instant_ewma(),
-    OneMin = folsom_ewma:one_minute_ewma(),
-    FiveMin = folsom_ewma:five_minute_ewma(),
-    FifteenMin = folsom_ewma:fifteen_minute_ewma(),
-
-    ets:insert(?METER_READER_TABLE,
-               {Name, #meter_reader{instant = Instant,
-                                    one = OneMin,
-                                    five = FiveMin,
-                                    fifteen = FifteenMin,
-                                    start_time = folsom_utils:now_epoch_micro()}}).
+    gen_server:call(?SERVER, {new, Name}).
 
 tick(Name) ->
     #meter_reader{instant = Instant,
@@ -161,3 +161,46 @@ calc_acceleration(Rate1, Rate2, Interval) ->
 get_rate(Value1, Value2, Interval) ->
     Delta = Value1 - Value2,
     Delta / Interval.
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+init([]) ->
+    process_flag(trap_exit, true),
+    {ok, #state{}}.
+
+handle_call({new, Name}, _From, State) ->
+    Reply = case ets:member(?METER_READER_TABLE, Name) of
+                false ->
+                    ok = folsom_meter_timer_server:register(Name, folsom_metrics_meter_reader),
+                    Instant = folsom_ewma:instant_ewma(),
+                    OneMin = folsom_ewma:one_minute_ewma(),
+                    FiveMin = folsom_ewma:five_minute_ewma(),
+                    FifteenMin = folsom_ewma:fifteen_minute_ewma(),
+
+                    ets:insert(?METER_READER_TABLE,
+                               {Name, #meter_reader{instant = Instant,
+                                                    one = OneMin,
+                                                    five = FiveMin,
+                                                    fifteen = FifteenMin,
+                                                    start_time = folsom_utils:now_epoch_micro()}}),
+                    true = ets:insert(?FOLSOM_TABLE, {Name, #metric{type = meter_reader}});
+                true ->
+                    true
+            end,
+    {reply, Reply, State}.
+
+handle_cast(_Request, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+format_status(_Opt, Status) ->
+    Status.

--- a/src/folsom_sup.erl
+++ b/src/folsom_sup.erl
@@ -92,7 +92,41 @@ init([]) ->
     SlideSup = {folsom_sample_slide_sup, {folsom_sample_slide_sup, start_link, []},
                 permanent, 5000, supervisor, [folsom_sample_slide_sup]},
 
-    {ok, {SupFlags, [SlideSup, TimerServer, HistETSServer]}}.
+    SpiralServer = {folsom_metrics_spiral,
+                    {folsom_metrics_spiral, start_link, []},
+                    Restart, Shutdown, Type, [folsom_metrics_spiral]},
+
+    HistoryServer = {folsom_metrics_history,
+                    {folsom_metrics_history, start_link, []},
+                    Restart, Shutdown, Type, [folsom_metrics_history]},
+
+    HistogramServer = {folsom_metrics_histogram,
+                       {folsom_metrics_histogram, start_link, []},
+                       Restart, Shutdown, Type, [folsom_metrics_histogram]},
+
+    DurationServer = {folsom_metrics_duration,
+                      {folsom_metrics_duration, start_link, []},
+                      Restart, Shutdown, Type, [folsom_metrics_duration]},
+
+    CounterServer = {folsom_metrics_counter,
+                     {folsom_metrics_counter, start_link, []},
+                     Restart, Shutdown, Type, [folsom_metrics_counter]},
+
+    GaugeServer = {folsom_metrics_gauge,
+                     {folsom_metrics_gauge, start_link, []},
+                     Restart, Shutdown, Type, [folsom_metrics_gauge]},
+
+    MeterServer = {folsom_metrics_meter,
+                   {folsom_metrics_meter, start_link, []},
+                   Restart, Shutdown, Type, [folsom_metrics_meter]},
+
+    MeterReaderServer = {folsom_metrics_meter_reader,
+                         {folsom_metrics_meter_reader, start_link, []},
+                         Restart, Shutdown, Type, [folsom_metrics_meter_reader]},
+
+    {ok, {SupFlags, [SlideSup, TimerServer, HistETSServer, SpiralServer, HistoryServer,
+                     HistogramServer, DurationServer, CounterServer, GaugeServer,
+                     MeterServer, MeterReaderServer]}}.
 
 %%%===================================================================
 %%% Internal functions

--- a/test/folsom_erlang_checks.erl
+++ b/test/folsom_erlang_checks.erl
@@ -130,7 +130,15 @@ populate_metrics() ->
 
     [ok = folsom_metrics:notify({<<"hugedata">>, Value}) || Value <- ?HUGEDATA],
 
-    [ok = folsom_metrics:notify({exdec, Value}) || Value <- lists:seq(1, 100000)],
+    [ok = folsom_metrics:notify({exdec, Value}) || Value <- lists:seq(1, 50000)],
+
+    %% Force a priority change in folson_sample_exdec:priority/1
+    receive
+    after 1000 ->
+            ok
+    end,
+
+    [ok = folsom_metrics:notify({exdec, Value}) || Value <- lists:seq(50000, 100000)],
 
     [ok = folsom_metrics:notify({none, Value}) || Value <- ?DATA],
 

--- a/test/folsom_tests.erl
+++ b/test/folsom_tests.erl
@@ -55,7 +55,9 @@ run_test_() ->
       {"c compiler test",
        fun folsom_erlang_checks:c_compiler_used/0},
       {"create and delete tests",
-       fun folsom_erlang_checks:create_delete_metrics/0}]}.
+       fun folsom_erlang_checks:create_delete_metrics/0},
+      {"ETS leak tests",
+       fun folsom_erlang_checks:check_ets_leak/0}]}.
 
 configure_test_() ->
     {foreach, fun setup_app/0, fun cleanup_app/1,


### PR DESCRIPTION
Fixes #2

If you're creating a lot of metrics this could be a performance concern. I'm not sure how people use it in general but I'm usually creating metrics on the fly for e.g. HTTP status codes, where the number is limited.