### PR TITLE
Refactor random calls 

### DIFF
--- a/include/folsom.hrl
+++ b/include/folsom.hrl
@@ -15,12 +15,6 @@
 -define(DEFAULT_INTERVAL, 5000).
 -define(DEFAULT_SAMPLE_TYPE, uniform).
 
--ifdef(use_rand).
--define(SEED, rand:seed(exsplus)).
--else.
--define(SEED, os:timestamp()).
--endif.
-
 -record(spiral, {
           tid = folsom_metrics_histogram_ets:new(folsom_spiral,
                                                  [set,
@@ -42,15 +36,13 @@
           window = ?DEFAULT_SLIDING_WINDOW,
           size = ?DEFAULT_SIZE,
           reservoir = folsom_metrics_histogram_ets:new(folsom_slide_uniform,[set, {write_concurrency, true}, public]),
-          seed = ?SEED,
           server
          }).
 
 -record(uniform, {
           size = ?DEFAULT_SIZE,
           n = 1,
-          reservoir = folsom_metrics_histogram_ets:new(folsom_uniform,[set, {write_concurrency, true}, public]),
-          seed = ?SEED
+          reservoir = folsom_metrics_histogram_ets:new(folsom_uniform,[set, {write_concurrency, true}, public])
          }).
 
 -record(exdec, {
@@ -58,7 +50,6 @@
           next = 0,
           alpha = ?DEFAULT_ALPHA,
           size = ?DEFAULT_SIZE,
-          seed = ?SEED,
           n = 1,
           reservoir = folsom_metrics_histogram_ets:new(folsom_exdec,[ordered_set, {write_concurrency, true}, public])
          }).

--- a/rebar.config
+++ b/rebar.config
@@ -10,6 +10,6 @@
             {platform_define, "18|19|^2", use_update_counter_4}
            ]}.
 
-{profiles, [{test, [{deps, [meck]}]}]}.
+{profiles, [{test, [{deps, [meck, proper]}]}]}.
 
 {cover_enabled, true}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -6,7 +6,8 @@ case erlang:function_exported(rebar3, main, 1) of
         %% profiles
         [{deps, [
             {bear, ".*", {git, "https://github.com/folsom-project/bear.git", {tag, "0.8.7"}}},
-            {meck, ".*", {git, "https://github.com/eproxus/meck", {tag, "0.8.13"}}}
+            {meck, ".*", {git, "https://github.com/eproxus/meck", {tag, "0.8.13"}}},
+            {proper, ".*", {git, "https://github.com/proper-testing/proper", {tag, "v1.3"}}}
         ]} | lists:keydelete(deps, 1, CONFIG)]
 end.
 

--- a/src/folsom_sample_slide_uniform.erl
+++ b/src/folsom_sample_slide_uniform.erl
@@ -51,7 +51,7 @@ update(#slide_uniform{reservoir = Reservoir, size = Size} = Sample0, Value) ->
     MCnt = folsom_utils:update_counter(Reservoir, Moment, 1),
     Sample = case MCnt > Size of
                  true ->
-                     {Rnd, _NewSeed} = ?RANDOM:uniform_s(MCnt, ?SEED),
+                     Rnd = folsom_utils:rand_uniform(MCnt),
                      maybe_update(Reservoir, {{Moment, Rnd}, Value}, Size),
                      Sample0;
                  false ->

--- a/src/folsom_sample_uniform.erl
+++ b/src/folsom_sample_uniform.erl
@@ -53,11 +53,11 @@ update(#uniform{size = Size, reservoir = Reservoir, n = N} = Sample, Value) when
     ets:insert(Reservoir, {N, Value}),
     Sample#uniform{n = N + 1};
 
-update(#uniform{reservoir = Reservoir, size = Size, n = N, seed = Seed} = Sample,
+update(#uniform{reservoir = Reservoir, size = Size, n = N} = Sample,
        Value) ->
-    {Rnd, New_seed} = ?RANDOM:uniform_s(N, Seed),
+    Rnd = folsom_utils:rand_uniform(N),
     maybe_update(Rnd, Size, Value, Reservoir),
-    Sample#uniform{n = N + 1, seed = New_seed}.
+    Sample#uniform{n = N + 1}.
 
 get_values(#uniform{reservoir = Reservoir}) ->
     {_, Values} = lists:unzip(ets:tab2list(Reservoir)),

--- a/src/folsom_utils.erl
+++ b/src/folsom_utils.erl
@@ -33,7 +33,8 @@
          timestamp/0,
          get_ets_size/1,
          update_counter/3,
-         update_counter_no_exceptions/3
+         update_counter_no_exceptions/3,
+         rand_uniform/1
         ]).
 
 to_atom(Binary) when is_binary(Binary) ->
@@ -114,5 +115,26 @@ update_counter_no_exceptions(Tid, Key, Value) when is_integer(Value) ->
         _ ->
             ets:update_counter(Tid, Key, Value)
     end.
+
+-endif.
+
+
+-ifdef(use_rand).
+
+rand_uniform(N) ->
+    rand:uniform(N).
+
+-else.
+
+rand_uniform(N) ->
+    %% ensure seed is initialized
+    %% simluating new `rand' module's behaviour
+    case get(random_seed) of
+        undefined ->
+            random:seed(os:timestamp());
+        {_, _, _} ->
+            ok
+    end,
+    random:uniform(N).
 
 -endif.

--- a/test/slide_statem_eqc.erl
+++ b/test/slide_statem_eqc.erl
@@ -27,17 +27,23 @@
 
 -ifdef(TEST).
 -ifdef(EQC).
-
--include("folsom.hrl").
+-define(QC_MOD, eqc).
 
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
+-else.
+-define(QC_MOD, proper).
+
+-include_lib("proper/include/proper.hrl").
+-endif.
+
+-include("folsom.hrl").
+
 -include_lib("eunit/include/eunit.hrl").
 
-
-
+-define(NUMTESTS, 500).
 -define(QC_OUT(P),
-        eqc:on_output(fun(Str, Args) ->
+        ?QC_MOD:on_output(fun(Str, Args) ->
                               io:format(user, Str, Args) end, P)).
 
 -define(WINDOW, 60).
@@ -112,12 +118,12 @@ prop_window_test_() ->
      fun() -> ok end,
      fun(_X) -> (catch meck:unload(folsom_utils)), folsom:stop() end,
      [{"QuickCheck Test",
-       {timeout, Seconds*2, fun() -> true = eqc:quickcheck(eqc:testing_time(Seconds, ?QC_OUT(prop_window()))) end
+       {timeout, Seconds*2, fun() -> true = ?QC_MOD:quickcheck(?QC_MOD:numtests(?NUMTESTS, ?QC_OUT(prop_window()))) end
        }}]}.
 
 prop_window() ->
-    folsom:start(),
-    (catch meck:new(folsom_utils)),
+    {ok, _} = application:ensure_all_started(folsom),
+    (catch meck:new(folsom_utils, [passthrough])),
     ?FORALL(Cmds, commands(?MODULE),
             aggregate(command_names(Cmds),
             begin
@@ -125,7 +131,7 @@ prop_window() ->
                 {Actual, Expected} = case S#state.sample of
                                          undefined ->
                                              {S#state.values, []};
-                                         Sample ->
+                                         _Sample ->
                                              A = folsom_metrics:get_metric_value(S#state.name),
                                              E = [V || {K, V} <- S#state.values, K >= S#state.moment - ?WINDOW],
                                              folsom_metrics:delete_metric(S#state.name),
@@ -146,7 +152,7 @@ new_histo() ->
     {Ref, Slide}.
 
 tick(Moment) ->
-    IncrBy = trunc(random:uniform(10)),
+    IncrBy = trunc(folsom_utils:rand_uniform(10)),
     meck:expect(folsom_utils, now_epoch, fun() -> Moment + IncrBy end),
     Moment+IncrBy.
 
@@ -164,5 +170,4 @@ get_values(Sample) ->
 trim(L, Moment, Window) ->
     [{K, V} || {K, V} <- L, K >= Moment - Window].
 
--endif.
 -endif.

--- a/test/slide_uniform_eqc.erl
+++ b/test/slide_uniform_eqc.erl
@@ -27,15 +27,23 @@
 
 -ifdef(TEST).
 -ifdef(EQC).
--include("folsom.hrl").
+-define(QC_MOD, eqc).
 
 -include_lib("eqc/include/eqc.hrl").
 -include_lib("eqc/include/eqc_statem.hrl").
+-else.
+-define(QC_MOD, proper).
+
+-include_lib("proper/include/proper.hrl").
+-endif.
+
+-include("folsom.hrl").
+
 -include_lib("eunit/include/eunit.hrl").
 
 -define(NUMTESTS, 200).
 -define(QC_OUT(P),
-        eqc:on_output(fun(Str, Args) ->
+        ?QC_MOD:on_output(fun(Str, Args) ->
                               io:format(user, Str, Args) end, P)).
 
 -define(WINDOW, 60).
@@ -67,7 +75,7 @@ next_state(S, V, {call, ?MODULE, new_histo, []}) ->
 next_state(S, V, {call, ?MODULE, tick, [_Moment]}) ->
     S#state{moment=V};
 next_state(#state{moment=Moment, values=Values0, sample=Sample, count=Count}=S, NewSample, {call, ?MODULE, update, [_, Val]}) ->
-    S#state{values={call, slide_uniform_eqc, new_state_values, [Sample, Moment, Values0, Val, Count]},
+    S#state{values={call, ?MODULE, new_state_values, [Sample, Moment, Values0, Val, Count]},
             count={call, orddict, update_counter, [Moment, 1, Count]},
             sample=NewSample};
 next_state(#state{values=Values, moment=Moment}=S, _V, {call, ?MODULE, trim, _}) ->
@@ -111,13 +119,15 @@ prop_window_test_() ->
     {setup, fun() -> ok end, fun(_X) -> (catch meck:unload(folsom_utils)), folsom:stop() end,
      fun(_X) ->
                 {timeout, 30,
-                           ?_assert(eqc:quickcheck(eqc:numtests(?NUMTESTS, ?QC_OUT(prop_window()))))} end}.
+                           ?_assert(?QC_MOD:quickcheck(?QC_MOD:numtests(?NUMTESTS, ?QC_OUT(prop_window()))))} end}.
 
 prop_window() ->
-    folsom:start(),
-    (catch meck:new(folsom_utils)),
-    (catch meck:expect(folsom_utils, update_counter, fun(Tid, Key, Value) -> meck:passthrough([Tid, Key, Value]) end)),
-    (catch meck:expect(folsom_utils, timestamp, fun() -> Res = os:timestamp(), put(timestamp, Res), Res end)),
+    {ok, _} = application:ensure_all_started(folsom),
+    (catch meck:new(folsom_utils, [passthrough])),
+    (catch meck:expect(folsom_utils, rand_uniform, fun(N) -> Rnd = meck:passthrough([N]),
+                                                             put({?MODULE, rand_uniform}, Rnd),
+                                                             Rnd
+                                                   end)),
     ?FORALL(Cmds, commands(?MODULE),
             aggregate(command_names(Cmds),
                       begin
@@ -148,7 +158,7 @@ new_histo() ->
     {Ref, Slide}.
 
 tick(Moment) ->
-    IncrBy = trunc(random:uniform(10)),
+    IncrBy = trunc(folsom_utils:rand_uniform(10)),
     meck:expect(folsom_utils, now_epoch, fun() -> Moment + IncrBy end),
     meck:expect(folsom_utils, now_epoch, fun(_Now) -> Moment + IncrBy end),
     Moment+IncrBy.
@@ -178,7 +188,7 @@ new_state_values(_Sample, Moment, Values, Val, Count) ->
     case Cnt > ?SIZE of
         true ->
             %% replace
-            {Rnd, _} = random:uniform_s(Cnt, get(timestamp)),
+            Rnd = get({?MODULE, rand_uniform}),
             case Rnd =< ?SIZE of
                 true ->
                     lists:keyreplace({Moment, Rnd}, 1, Values, {{Moment, Rnd}, Val});
@@ -190,5 +200,4 @@ new_state_values(_Sample, Moment, Values, Val, Count) ->
             Values ++ [{{Moment, Cnt}, Val}]
     end.
 
--endif.
 -endif.


### PR DESCRIPTION
The intention is to get closer to the new `rand` usage.

Minor advantages:
- Only initialize the random seed if necessary (slide_uniform). Even
  short-running processes are likely to bump more than one metric during
  their lifetime, avoiding seeding for each will save a few syscalls.
- With the seed stored in the main histogram table (exdec, uniform), two
  parallel processes might use the same seed (which is not a disaster,
  but probably not intended)
- Not seeding the new `rand` module explicitly means it will use the most
  up-to-date default algorithm. (exsplus is already deprecated)

I might be missing the main reason why the seed was stored in the sample record,
which might invalidate this change.