### PR TITLE
Fix generator for older Erlang versions

### DIFF
--- a/src/folsom_vm_metrics.erl
+++ b/src/folsom_vm_metrics.erl
@@ -267,7 +267,7 @@ get_ets_dets_info(Type, Tab) ->
     end.
 
 ip_to_binary(Tuple) ->
-    iolist_to_binary(string:join([integer_to_list(L) || L <:- Tuple], ".")).
+    iolist_to_binary(string:join([integer_to_list(L) || L <- tuple_to_list(Tuple)], ".")).
 
 convert_port_info({name, Name}) ->
     {name, list_to_binary(Name)};


### PR DESCRIPTION
Downgrade a modern generator syntax (available since Erlang 28) to a more compatible one.

I couldn't find any Erlang version compatibility matrix so I believe we shouldn't restrict it to Erlang 28+ only.